### PR TITLE
[BUG] Tab selected prop was not working

### DIFF
--- a/lib/components/Tabs/Tabs.js
+++ b/lib/components/Tabs/Tabs.js
@@ -52,7 +52,7 @@ var Tabs = exports.Tabs = function (_Component) {
 		// default to first selected item
 		var selected = children[0] && children[0].key;
 
-		if (children.count > 0) {
+		if (children.length > 0) {
 			children.some(function (tab) {
 				if (tab.props.selected) {
 					selected = tab.key;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-sprucebot",
-    "version": "0.10.10",
+    "version": "0.10.11",
     "main": "lib/Sprucebot.js",
     "description": "React components for your Sprucebot Skill 💪🏼",
     "keywords": [

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -13,7 +13,7 @@ export class Tabs extends Component {
 		// default to first selected item
 		let selected = children[0] && children[0].key
 
-		if (children.count > 0) {
+		if (children.length > 0) {
 			children.some(tab => {
 				if (tab.props.selected) {
 					selected = tab.key


### PR DESCRIPTION
@sprucelabsai/engineers
@liquidg3 

## Description 
Tab selected prop was not working due to count vs length
## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
Passing in 'selected={true}' now sets the default tab 