### PR TITLE
Updated Jest to test only src directory and ignore any coverage from …

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
         "styled-components": "^2.2.2"
     },
     "jest": {
+        "roots": ["<rootDir>/src/"],
         "coverageDirectory": "./coverage/",
-        "collectCoverage": true
+        "collectCoverage": true,
+        "coveragePathIgnorePatterns": ["<rootDir>/lib/", "<rootDir>/node_modules/"]
     }
 }


### PR DESCRIPTION
…the compiled lib dir

@sprucelabsai/engineers

## Description 
Currently our tests are setup to run on the build/lib folder as well and babel sometimes does not transpile tests in a good way. Also, it doesnt make sense to show coverage on the compiled directory so this change will correctly show the files devs work on.

NOTE: This PR shows the coverage dropped because, now its not accounting for the coverage gains that come from jest running the compiled code. 64% seems to be the accurate source code coverage.

## Type
- [ ] Feature
- [ ] Bug
- [x] Tech debt

## Steps to Test or Reproduce
### Before
![screen shot 2018-01-18 at 3 34 31 pm](https://user-images.githubusercontent.com/539311/35124943-2be5d83e-fc65-11e7-9d4d-4b4cfb4d9c10.png)

### After
![screen shot 2018-01-18 at 3 32 49 pm](https://user-images.githubusercontent.com/539311/35124874-df0d93e4-fc64-11e7-903c-e0045fbceef8.png)

