### PR TITLE
Features and cleanup

### DIFF
--- a/lib/skillskit/next/Page.js
+++ b/lib/skillskit/next/Page.js
@@ -221,43 +221,42 @@ var Page = function Page(Wrapped) {
 								case 13:
 									state = store.getState();
 
-									props = _extends({}, props, state);
 
-									if (props.auth && !props.auth.error) {
-										props.auth.role = props.config.DEV_MODE && getCookie('devRole', req, res) || props.auth.role;
+									if (state.auth && !state.auth.error) {
+										state.auth.role = state.config.DEV_MODE && getCookie('devRole', req, res) || state.auth.role;
 									}
 
 									if (!ConnectedWrapped.getInitialProps) {
-										_context2.next = 26;
+										_context2.next = 25;
 										break;
 									}
 
 									args = Array.from(_args2);
 
-									args[0] = _extends({}, props, args[0]);
+									args[0] = _extends({}, args[0], state);
 									_context2.t1 = _extends;
 									_context2.t2 = {};
 									_context2.t3 = props;
-									_context2.next = 24;
+									_context2.next = 23;
 									return ConnectedWrapped.getInitialProps.apply(this, args);
 
-								case 24:
+								case 23:
 									_context2.t4 = _context2.sent;
 									props = (0, _context2.t1)(_context2.t2, _context2.t3, _context2.t4);
 
-								case 26:
+								case 25:
 									redirect = props.redirect || false;
 
 
 									if (query.back && query.jwt && query.back.search('sprucebot.com') > 0) {
 										// if there is a jwt, we are being authed
 										redirect = query.back;
-									} else if (!redirect && !props.public && (!props.auth || !props.auth.role || props.auth.error)) {
+									} else if (!redirect && !props.public && (!state.auth || !state.auth.role || state.auth.error)) {
 										// no redirect is set, we're not public, but auth failed
 										redirect = '/unauthorized';
 									} else if (!redirect && !props.public) {
 										// all things look good, lets just make sure we're in the right area (owner, teammate, or guest)
-										role = props.auth.role;
+										role = state.auth.role;
 										firstPart = props.pathname.split('/')[1];
 										_jwt = query.jwt, rest = _objectWithoutProperties(query, ['jwt']);
 										queryString = _qs2.default.stringify(rest);
@@ -272,7 +271,7 @@ var Page = function Page(Wrapped) {
 									}
 
 									if (!(redirect && res)) {
-										_context2.next = 35;
+										_context2.next = 34;
 										break;
 									}
 
@@ -283,14 +282,14 @@ var Page = function Page(Wrapped) {
 									res.finished = true;
 									return _context2.abrupt('return');
 
-								case 35:
+								case 34:
 									if (redirect) {
 										window.location.href = redirect;
 									}
 
-								case 36:
+								case 35:
 									// if we are /unauthorized, don't have a cookie, but have NOT done cookie check
-									if (props.pathname === '/unauthorized' && (!props.auth || !props.auth.role)) {
+									if (props.pathname === '/unauthorized' && (!state.auth || !state.auth.role)) {
 										props.attemptingReAuth = true;
 									}
 
@@ -298,7 +297,7 @@ var Page = function Page(Wrapped) {
 									// No circular dependencies
 									return _context2.abrupt('return', props);
 
-								case 38:
+								case 37:
 								case 'end':
 									return _context2.stop();
 							}

--- a/lib/skillskit/store/apiClient.js
+++ b/lib/skillskit/store/apiClient.js
@@ -18,6 +18,10 @@ var _http = require('http');
 
 var _http2 = _interopRequireDefault(_http);
 
+var _qs = require('qs');
+
+var _qs2 = _interopRequireDefault(_qs);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
@@ -45,12 +49,12 @@ var ApiClient = function () {
 				var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 				return new Promise(function () {
 					var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(resolve, reject) {
-						var body, headers, fetchOptions, agent, response, json;
+						var body, query, headers, fetchOptions, agent, fetchUrl, response, json;
 						return regeneratorRuntime.wrap(function _callee$(_context) {
 							while (1) {
 								switch (_context.prev = _context.next) {
 									case 0:
-										body = options.body;
+										body = options.body, query = options.query;
 										_context.prev = 1;
 										headers = {
 											Accept: 'application/json',
@@ -75,45 +79,54 @@ var ApiClient = function () {
 											fetchOptions.headers['x-skill-jwt'] = _this.jwt;
 										}
 
-										// Start network request
-										_context.next = 8;
-										return (0, _isomorphicFetch2.default)('' + endpoint + path, fetchOptions);
+										fetchUrl = '' + endpoint + path;
 
-									case 8:
+
+										if (query) {
+											fetchUrl =
+											// determine if we're appending or creating a query string
+											fetchUrl.indexOf('?') > -1 ? '' + fetchUrl + _qs2.default.stringify(query) : fetchUrl + '?' + _qs2.default.stringify(query);
+										}
+
+										// Start network request
+										_context.next = 10;
+										return (0, _isomorphicFetch2.default)(fetchUrl, fetchOptions);
+
+									case 10:
 										response = _context.sent;
-										_context.next = 11;
+										_context.next = 13;
 										return response.json();
 
-									case 11:
+									case 13:
 										json = _context.sent;
 
 										if (response.ok) {
-											_context.next = 15;
+											_context.next = 17;
 											break;
 										}
 
 										console.log('Request not okay', response.status, json);
 										return _context.abrupt('return', reject(json));
 
-									case 15:
+									case 17:
 
 										resolve(json);
-										_context.next = 22;
+										_context.next = 24;
 										break;
 
-									case 18:
-										_context.prev = 18;
+									case 20:
+										_context.prev = 20;
 										_context.t0 = _context['catch'](1);
 
 										console.error('Response failure', _context.t0);
 										reject(_context.t0);
 
-									case 22:
+									case 24:
 									case 'end':
 										return _context.stop();
 								}
 							}
-						}, _callee, _this, [[1, 18]]);
+						}, _callee, _this, [[1, 20]]);
 					}));
 
 					return function (_x2, _x3) {

--- a/lib/skillskit/store/middleware/loggerMiddleware.js
+++ b/lib/skillskit/store/middleware/loggerMiddleware.js
@@ -7,13 +7,16 @@ exports.default = loggerMiddleware;
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var loggingEnabled = false;
-
 function loggerMiddleware() {
-	return function () {
+	return function (_ref) {
+		var getState = _ref.getState;
+
+		var _getState = getState(),
+		    config = _getState.config;
+
 		return function (next) {
 			return function (action) {
-				if (loggingEnabled) {
+				if (config.DEV_MODE) {
 					var type = action.type,
 					    types = action.types,
 					    rest = _objectWithoutProperties(action, ["type", "types"]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-sprucebot",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "main": "lib/Sprucebot.js",
     "description": "React components for your Sprucebot Skill 💪🏼",
     "keywords": [

--- a/src/skillskit/next/Page.js
+++ b/src/skillskit/next/Page.js
@@ -68,20 +68,16 @@ const Page = Wrapped => {
 			}
 
 			const state = store.getState()
-			props = {
-				...props,
-				...state
-			}
 
-			if (props.auth && !props.auth.error) {
-				props.auth.role =
-					(props.config.DEV_MODE && getCookie('devRole', req, res)) ||
-					props.auth.role
+			if (state.auth && !state.auth.error) {
+				state.auth.role =
+					(state.config.DEV_MODE && getCookie('devRole', req, res)) ||
+					state.auth.role
 			}
 
 			if (ConnectedWrapped.getInitialProps) {
 				const args = Array.from(arguments)
-				args[0] = { ...props, ...args[0] }
+				args[0] = { ...args[0], ...state }
 				props = {
 					...props,
 					...(await ConnectedWrapped.getInitialProps.apply(this, args))
@@ -96,13 +92,13 @@ const Page = Wrapped => {
 			} else if (
 				!redirect &&
 				!props.public &&
-				(!props.auth || !props.auth.role || props.auth.error)
+				(!state.auth || !state.auth.role || state.auth.error)
 			) {
 				// no redirect is set, we're not public, but auth failed
 				redirect = '/unauthorized'
 			} else if (!redirect && !props.public) {
 				// all things look good, lets just make sure we're in the right area (owner, teammate, or guest)
-				const role = props.auth.role
+				const role = state.auth.role
 				const firstPart = props.pathname.split('/')[1]
 
 				const { jwt, ...rest } = query
@@ -130,7 +126,7 @@ const Page = Wrapped => {
 			// if we are /unauthorized, don't have a cookie, but have NOT done cookie check
 			if (
 				props.pathname === '/unauthorized' &&
-				(!props.auth || !props.auth.role)
+				(!state.auth || !state.auth.role)
 			) {
 				props.attemptingReAuth = true
 			}

--- a/src/skillskit/store/apiClient.js
+++ b/src/skillskit/store/apiClient.js
@@ -1,6 +1,7 @@
 import fetch from 'isomorphic-fetch'
 import https from 'https'
 import http from 'http'
+import qs from 'qs'
 
 const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DEL']
 
@@ -14,7 +15,7 @@ class ApiClient {
 		methods.forEach(method => {
 			this[method.toLowerCase()] = (path, options = {}) =>
 				new Promise(async (resolve, reject) => {
-					const { body } = options
+					const { body, query } = options
 					try {
 						let headers = {
 							Accept: 'application/json',
@@ -39,8 +40,18 @@ class ApiClient {
 							fetchOptions.headers['x-skill-jwt'] = this.jwt
 						}
 
+						let fetchUrl = `${endpoint}${path}`
+
+						if (query) {
+							fetchUrl =
+								// determine if we're appending or creating a query string
+								fetchUrl.indexOf('?') > -1
+									? `${fetchUrl}${qs.stringify(query)}`
+									: `${fetchUrl}?${qs.stringify(query)}`
+						}
+
 						// Start network request
-						const response = await fetch(`${endpoint}${path}`, fetchOptions)
+						const response = await fetch(fetchUrl, fetchOptions)
 						const json = await response.json()
 						if (!response.ok) {
 							console.log('Request not okay', response.status, json)

--- a/src/skillskit/store/middleware/loggerMiddleware.js
+++ b/src/skillskit/store/middleware/loggerMiddleware.js
@@ -1,9 +1,8 @@
-const loggingEnabled = false
-
 export default function loggerMiddleware() {
-	return () => {
+	return ({ getState }) => {
+		const { config } = getState()
 		return next => action => {
-			if (loggingEnabled) {
+			if (config.DEV_MODE) {
 				const { type, types, ...rest } = action
 				console.log(`Action ${type || types}`, rest)
 			}


### PR DESCRIPTION
@sprucelabsai/engineers

## Description 

- Allows apiClient to add `query` params to api requests
- Logs redux actions in DEV_MODE server side
- Cleanup `Page.getInitialProps` so there's no conflict with the connected redux state. -- There was no real issue there, I just wanted to clean things up a bit

## Type
- [x] Feature
- [ ] Bug
- [x] Tech debt

## Steps to Test or Reproduce
Api request actions can now pass query params
`return {types:[...], promise: client => client.get('endpoint', {query: {param1: 'test'}})}`
`// http://api.com/endpoint?param1=test`

Look for console.logs after firing any redux action

`Page.getInitialProps` shouldn't cause regressions anywhere 🙃
