### PR TITLE
SB-918 - Refactor Dialog position to use simple flexbox center

### DIFF
--- a/lib/components/Dialog/Dialog.js
+++ b/lib/components/Dialog/Dialog.js
@@ -12,6 +12,14 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _styledComponents = require('styled-components');
+
+var _styledComponents2 = _interopRequireDefault(_styledComponents);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -38,6 +46,40 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var DialogUnderlay = _styledComponents2.default.div.attrs({
+	className: function className(_ref) {
+		var show = _ref.show;
+		return (0, _classnames2.default)('dialog_underlay', show ? 'on' : 'off', 'container');
+	}
+}).withConfig({
+	displayName: 'Dialog__DialogUnderlay',
+	componentId: 'ta61od-0'
+})(['position:absolute;left:0;right:0;top:0;bottom:0;z-index:1;background-color:rgba(0,0,0,0.6);display:flex;justify-content:center;align-items:center;min-height:', 'px;padding:20px;'], function (_ref2) {
+	var height = _ref2.height;
+	return height + 40;
+});
+
+var DialogContainer = _styledComponents2.default.div.attrs({
+	className: function className(_ref3) {
+		var show = _ref3.show,
+		    _className = _ref3.className;
+		return (0, _classnames2.default)('dialog', _className, show ? 'on' : 'off');
+	}
+}).withConfig({
+	displayName: 'Dialog__DialogContainer',
+	componentId: 'ta61od-1'
+})(['transition:opacity 1s ease-in-out;opacity:', ';background-color:#fff;border-radius:4px;z-index:2;padding:20px;margin:auto -20px;width:90%;max-width:500px;'], function (_ref4) {
+	var opacity = _ref4.opacity;
+	return opacity || 0;
+});
+var DialogCloseButton = (0, _styledComponents2.default)(_Button2.default).attrs({
+	className: 'btn__close_dialog',
+	remove: true
+}).withConfig({
+	displayName: 'Dialog__DialogCloseButton',
+	componentId: 'ta61od-2'
+})(['display:block;position:absolute;top:15px;right:20px;']);
+
 var Dialog = function (_Component) {
 	_inherits(Dialog, _Component);
 
@@ -46,94 +88,36 @@ var Dialog = function (_Component) {
 
 		var _this = _possibleConstructorReturn(this, (Dialog.__proto__ || Object.getPrototypeOf(Dialog)).call(this, props));
 
-		_this.showing = false;
-		_this.wrapper = false;
 		_this.state = {
-			top: -1,
-			left: -1,
 			width: -1,
-			height: 500,
-			opacity: 0
-
-			// for resize callbacks
-		};_this.position = _this.position.bind(_this);
+			height: 500
+		};
 		return _this;
 	}
 
 	_createClass(Dialog, [{
-		key: 'componentDidUpdate',
-		value: function componentDidUpdate(prevProps, prevState) {
-			if (!this.showing && this.props.show) {
-				this.position();
+		key: 'componentWillReceiveProps',
+		value: function componentWillReceiveProps(nextProps) {
+			var _this2 = this;
+
+			if (this.props.show !== nextProps.show) {
+				setTimeout(function () {
+					return _this2.setState({ opacity: nextProps.show ? 1 : 0 });
+				}, 100);
 			}
-			this.showing = this.props.show;
-		}
-	}, {
-		key: 'position',
-		value: function position() {
-			if (!this.wrapper) return;
-			// don't resize if we are not showing
-			var positionedParent = void 0;
-			var node = this.wrapper.parentNode;
-
-			while (node && node !== document.body) {
-				var pos = window.getComputedStyle(node).getPropertyValue('position').toLowerCase();
-
-				if (pos === 'relative' || pos === 'absolute') {
-					positionedParent = node;
-					node = null;
-				} else {
-					node = node.parentNode;
-				}
-			}
-
-			var screenWidth = void 0,
-			    scrollTop = document.body.scrollTop;
-
-			var w = window,
-			    d = document,
-			    e = d.documentElement,
-			    g = d.getElementsByTagName('body')[0],
-			    screenHeight = w.innerHeight || e.clientHeight || g.clientHeight;
-
-			if (!positionedParent) {
-				screenWidth = w.innerWidth || e.clientWidth || g.clientWidth;
-			} else {
-				screenWidth = positionedParent.offsetWidth;
-				scrollTop = document.body.scrollTop - positionedParent.offsetTop;
-			}
-
-			// center horizontally
-			var width = this.state.width > 0 ? this.state.width : Math.min(500, screenWidth * 0.9);
-			var left = (screenWidth - width) / 2;
-			var top = this.state.height >= screenHeight - 20 ? 20 : scrollTop + (screenHeight - this.state.height) / 2;
-
-			this.setState({ left: left, top: top });
 		}
 	}, {
 		key: 'setSize',
-		value: function setSize(_ref) {
-			var width = _ref.width,
-			    height = _ref.height;
+		value: function setSize(_ref5) {
+			var width = _ref5.width,
+			    height = _ref5.height;
 
-			this.setState({ width: width, height: height, opacity: 1 });
-			this.position();
-		}
-	}, {
-		key: 'componentDidMount',
-		value: function componentDidMount() {
-			window.addEventListener('resize', this.position);
-			this.position();
-		}
-	}, {
-		key: 'componentWillUnmount',
-		value: function componentWillUnmount() {
-			window.removeEventListener('resize', this.position);
+			this.setState({ width: width, height: height });
 		}
 	}, {
 		key: 'render',
 		value: function render() {
-			var _this2 = this;
+			var _this3 = this;
 
 			var _props = this.props,
 			    tag = _props.tag,
@@ -144,9 +128,8 @@ var Dialog = function (_Component) {
 			    props = _objectWithoutProperties(_props, ['tag', 'children', 'className', 'show', 'onTapClose']);
 
 			var _state = this.state,
-			    top = _state.top,
-			    left = _state.left,
-			    opacity = _state.opacity;
+			    opacity = _state.opacity,
+			    height = _state.height;
 
 			var Tag = tag;
 
@@ -155,38 +138,30 @@ var Dialog = function (_Component) {
 			}
 
 			return _react2.default.createElement(
-				'div',
-				{
-					ref: function ref(node) {
-						_this2.wrapper = node;
-					}
-				},
-				_react2.default.createElement('div', { className: 'dialog_underlay ' + (show ? 'on' : 'off') }),
+				DialogUnderlay,
+				{ show: show, height: height },
 				_react2.default.createElement(
 					_reactMeasure2.default,
 					{
 						bounds: true,
 						onResize: function onResize(contentRect) {
-							_this2.setSize({
+							_this3.setSize({
 								width: contentRect.bounds.width,
 								height: contentRect.bounds.height
 							});
 						}
 					},
-					function (_ref2) {
-						var measureRef = _ref2.measureRef;
+					function (_ref6) {
+						var measureRef = _ref6.measureRef;
 						return _react2.default.createElement(
-							Tag,
+							DialogContainer,
 							_extends({
-								style: { top: top, left: left, opacity: opacity },
-								ref: measureRef,
-								className: 'dialog ' + (className || '') + ' ' + (show ? 'on' : 'off')
+								innerRef: measureRef,
+								className: className,
+								show: show,
+								opacity: opacity
 							}, props),
-							onTapClose && _react2.default.createElement(_Button2.default, {
-								className: 'btn__close_dialog',
-								remove: true,
-								onClick: onTapClose
-							}),
+							onTapClose && _react2.default.createElement(DialogCloseButton, { onClick: onTapClose }),
 							children
 						);
 					}

--- a/lib/skillskit/index.js
+++ b/lib/skillskit/index.js
@@ -20,17 +20,16 @@ exports.default = {
 
 			var body = document.body;
 			var docEl = document.documentElement;
-			var computedStyle = window.getComputedStyle(elem);
 
 			var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
 			var clientTop = docEl.clientTop || body.clientTop || 0;
 			var top = box.top + scrollTop - clientTop;
-			var bottom = top + elem.clientHeight + parseFloat(computedStyle.paddingTop) + parseFloat(computedStyle.paddingBottom);
+			var bottom = top + elem.scrollHeight;
 
 			return bottom;
 		}
 
-		window.document.querySelectorAll('.container,.dialog').forEach(function (container) {
+		window.document.querySelectorAll('.container,.dialog_underlay').forEach(function (container) {
 			var bottom = getBottom(container);
 			if (bottom > height) {
 				height = bottom;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "dependencies": {
         "babel-polyfill": "^6.26.0",
         "babel-register": "^6.26.0",
+        "classnames": "^2.2.5",
         "cookies": "^0.7.1",
         "imagesloaded": "^4.1.4",
         "js-cookies": "^1.0.4",

--- a/src/skillskit/index.js
+++ b/src/skillskit/index.js
@@ -15,22 +15,17 @@ export default {
 
 			var body = document.body
 			var docEl = document.documentElement
-			const computedStyle = window.getComputedStyle(elem)
 
 			var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop
 			var clientTop = docEl.clientTop || body.clientTop || 0
 			var top = box.top + scrollTop - clientTop
-			var bottom =
-				top +
-				elem.clientHeight +
-				parseFloat(computedStyle.paddingTop) +
-				parseFloat(computedStyle.paddingBottom)
+			var bottom = top + elem.scrollHeight
 
 			return bottom
 		}
 
 		window.document
-			.querySelectorAll('.container,.dialog')
+			.querySelectorAll('.container,.dialog_underlay')
 			.forEach(container => {
 				let bottom = getBottom(container)
 				if (bottom > height) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,6 +1471,10 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"


### PR DESCRIPTION
[SB-918](https://jira.sprucelabs.ai/jira/browse/SB-918)

@sprucelabsai/engineers

## Description 
This pulls in the styles from __skill.scss in the web project and implements them as styled components.
Added a display:flex to the underlay to center the dialog rather than calculating it in the position() method.

## Type
- [x] Bug

## Steps to Test or Reproduce
Little Black Book skill had the best representation of this bug. When the dialog is shorter than the window height, it's position is centered.
When the dialog is taller than the window, it will render with 20px padding in the overlay and the window will grow to match the underlay height.
