### PR TITLE
SB-1118 - fix cannot read prop auth of undefined

### DIFF
--- a/lib/skillskit/next/_document.js
+++ b/lib/skillskit/next/_document.js
@@ -28,6 +28,8 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var debug = require('debug')('react-sprucebot');
+
 var MyDocument = function (_Document) {
 	_inherits(MyDocument, _Document);
 
@@ -89,7 +91,7 @@ var MyDocument = function (_Document) {
 				    query = _ref2.query,
 				    store = _ref2.store;
 
-				var sheet, _ref3, auth, config, whitelabel, orgWhitelabel, page, styleTags;
+				var sheet, page, styleTags, _store$getState, auth, config, whitelabel, orgWhitelabel;
 
 				return regeneratorRuntime.wrap(function _callee$(_context) {
 					while (1) {
@@ -97,26 +99,39 @@ var MyDocument = function (_Document) {
 							case 0:
 								// Build stylesheets from styled-components
 								sheet = new _styledComponents.ServerStyleSheet();
-								_ref3 = store && store.getState(), auth = _ref3.auth, config = _ref3.config;
-								whitelabel = config.WHITELABEL;
-
-								//we have any whitelabelling happening?
-
-								orgWhitelabel = void 0;
-
-								if (auth && auth.Location && auth.Location.Organization && auth.Location.Organization.allowWhiteLabelling && auth.Location.Organization.whiteLabellingStylesheetUrl) {
-									orgWhitelabel = auth.Location.Organization.whiteLabellingStylesheetUrl;
-								}
-
 								page = renderPage(function (App) {
 									return function (props) {
 										return sheet.collectStyles(_react2.default.createElement(App, props));
 									};
 								});
 								styleTags = sheet.getStyleElement();
+								// Store is undefined when hmr is the first
+								// request the server sees after boot
+								// Ideally store is always defined.
+								// Revisit when using `next>5.0.0`
+
+								if (store) {
+									_context.next = 6;
+									break;
+								}
+
+								debug('No store in _document');
+								return _context.abrupt('return', _extends({}, page, { styleTags: styleTags }));
+
+							case 6:
+								_store$getState = store.getState(), auth = _store$getState.auth, config = _store$getState.config;
+								whitelabel = config.WHITELABEL;
+								orgWhitelabel = void 0;
+
+								//we have any whitelabelling happening?
+
+								if (auth.Location && auth.Location.Organization && auth.Location.Organization.allowWhiteLabelling && auth.Location.Organization.whiteLabellingStylesheetUrl) {
+									orgWhitelabel = auth.Location.Organization.whiteLabellingStylesheetUrl;
+								}
+
 								return _context.abrupt('return', _extends({}, page, { styleTags: styleTags, whitelabel: whitelabel, auth: auth, config: config, orgWhitelabel: orgWhitelabel }));
 
-							case 8:
+							case 11:
 							case 'end':
 								return _context.stop();
 						}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "babel-register": "^6.26.0",
         "classnames": "^2.2.5",
         "cookies": "^0.7.1",
+        "debug": "^3.1.0",
         "imagesloaded": "^4.1.4",
         "js-cookies": "^1.0.4",
         "moment": "^2.19.3",


### PR DESCRIPTION
[SB-1118](https://jira.sprucelabs.ai/jira/browse/SB-1118)

@sprucelabsai/engineers

## Description 
It seems like the store is not defined when the server handles a hmr request before it's handled any other requests. This just backs out the rest of our page rendering logic for the hmr request

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
`DEBUG=react-sprucebot yarn local`
1. Start the skill and load the `/owner` page
2. Stop the server and restart
3. Wait for the hmr request from the still open `/owner` page
4. Notice ssr log `react-sprucebot No store in _document +4s`

